### PR TITLE
Translate some English strings into Spanish

### DIFF
--- a/examples/es/gapfill_examples.xml
+++ b/examples/es/gapfill_examples.xml
@@ -11,7 +11,7 @@
 <!-- question: 19  -->
   <question type="gapfill">
     <name>
-      <text>Images in tables (fruit)</text>
+      <text>Imágenes en tabla (fruta)</text>
     </name>
     <questiontext format="html">
       <text><![CDATA[<table class="gapfilltable" border="2" rules="rows"><colgroup> <col class="gapfillcol"> <col class="gapfillcol"> </colgroup>
@@ -88,7 +88,7 @@
 <!-- question: 31  -->
   <question type="gapfill">
     <name>
-      <text>Spanish CatMat</text>
+      <text>Spanish CatMat (3 tristes tigres)</text>
     </name>
     <questiontext format="html">
       <text><![CDATA[<p>Tres tristes tigres [tragan] trigo en el trigal.<br></p>]]></text>

--- a/examples/es/gapfill_examples.xml
+++ b/examples/es/gapfill_examples.xml
@@ -78,10 +78,10 @@
       <text></text>
     </correctfeedback>
     <partiallycorrectfeedback format="html">
-      <text><![CDATA[<p>Your answer is partially correct.</p>]]></text>
+      <text><![CDATA[<p>Su respuesta es parcialmente correcta.</p>]]></text>
     </partiallycorrectfeedback>
     <incorrectfeedback format="html">
-      <text><![CDATA[<p>Your answer is incorrect.</p>]]></text>
+      <text><![CDATA[<p>Su respuesta es incorrecta.</p>]]></text>
     </incorrectfeedback>
   </question>
 
@@ -163,10 +163,10 @@
       <text></text>
     </correctfeedback>
     <partiallycorrectfeedback format="html">
-      <text>Your answer is partially correct.</text>
+      <text>Su respuesta es parcialmente correcta.</text>
     </partiallycorrectfeedback>
     <incorrectfeedback format="html">
-      <text>Your answer is incorrect.</text>
+      <text>Su respuesta es incorrecta.</text>
     </incorrectfeedback>
   </question>
 


### PR DESCRIPTION
The example question names and feedback text inside the es examples/es/gapfill_examples.xml  file were  still in English. These are the Spanish translations.

Thanks in advance.

Your workaround seems to work just fine +1: 