### PR TITLE
Fix duplicate dragables in Moodle Mobile app

### DIFF
--- a/mobile/latest/addon-qtype-gapfill.html
+++ b/mobile/latest/addon-qtype-gapfill.html
@@ -12,9 +12,6 @@
         <p>
         <core-format-text *ngIf="question.optionsaftertext" [component]="component" [componentId]="componentId"
             [text]="question.text" (afterRender)="questionRendered()"></core-format-text></p>
-    <div class="answeroptions">
-    <core-format-text  [text]="question.answeroptions" ></core-format-text>
-    </div>
     <p><core-format-text *ngIf="!question.optionsaftertext"  [component]="component"
             [componentId]="componentId" [text]="question.text" (afterRender)="questionRendered()"></core-format-text></p>
         <core-format-text *ngIf="question.answers" [component]="component" [componentId]="componentId"

--- a/mobile/mobile.js
+++ b/mobile/mobile.js
@@ -59,9 +59,8 @@ var result = {
             var i;
             for (i = 0; i < draggables.length; i++) {
                 // If singleuse is set some fields may be hidden .
-               draggables[i].classList.remove('hide');
-              /* Optionsaftertext reference is to stop the listener being applied twice */
-                if (draggables[i].id && !this.question.optionsaftertext) {
+                draggables[i].classList.remove('hide');
+                if (draggables[i].id) {
                     draggables[i].addEventListener('click', function() {
                         self.LastItemClicked = pickAnswerOption(draggables, event);
                     });


### PR DESCRIPTION
This addresses issue #85 

I noticed that the dragable options are available in the question.html as well as question.answeroptions. I'm not sure if this was the case in earlier versions of the app, but simply removing question.answeroptions from the template seems to work. I also made a change in the js so the event listeners are still applied for options after text, otherwise questions with that option weren't working in mobile.

This fixes the issue I noticed, but I haven't tested exhaustively with all of the options available for the question type, so I'm not sure if this has repercussions elsewhere.